### PR TITLE
Change Download Link to Input

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Specifically, performance was improved by the following metrics:
 
 * __Size of HTML file reduced__ by __57%__ (from 41.5 KB to 17.7 KB)
 * __Total number of images reduced__ by __78%__ (from 42 to 9)
-* __Total size of website reduced__ by __50%__ (from 95.7 KB to 46.9 KB)
+* __Total size of website reduced__ by __50%__ (from 95.7 KB to 47 KB)
 
 This repository itself also provides an open forum for people to suggest continued improvements to the template and also allows
 developers to further extend the template.

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
                 <span class="name">Student Name, Identifier</span>
             </div>
 
-            <a id="download-xml" class="download-btn" href="#">Download</a>
+            <input type="button" id="download-xml" class="download-btn" value="Download" />
         </div>
 
         <div id="main">
@@ -407,7 +407,7 @@
           <div class="modal">
               <div class="header">
                   <h2>XML Output</h2>
-                  <a id="close-output-xml" class="close" href="#">X</a>
+                  <input type="button" id="close-output-xml" class="close" value="X" />
               </div>
               <label for="xml-output">XML Output</label>
               <textarea id="xml-output"></textarea>

--- a/style/main.css
+++ b/style/main.css
@@ -148,8 +148,10 @@ h1
 .download-btn
 {
   background: #FFF url(../images/download.gif) no-repeat 0.75em;
+  border: 0;
   border-radius: 0.4em;
   color: #555;
+  cursor: pointer;
   display: block;
   font-size: 0.7em;
   font-weight: bold;
@@ -671,8 +673,10 @@ table tr.intro-row td.amount
     -webkit-border-radius: 0.3125em;
     -moz-border-radius: 0.3125em;
     -webkit-border-radius: 0.3125em;
+    border: 0;
     border-radius: 0.3125em;
     color: #FFF;
+    cursor: pointer;
     float: right;
     font-size: 1em;
     font-weight: bold;


### PR DESCRIPTION
Fixes #8

Used `input[type="button"]` instead of `button` to avoid the need for a HTML5 element polyfill in older browsers
